### PR TITLE
Ensure params are cast as int

### DIFF
--- a/pageview_digest/wsgi.py
+++ b/pageview_digest/wsgi.py
@@ -88,8 +88,9 @@ def application(env, start_response):
     if path == "/trending.json" and "site" in params:
         try:
             site = params.get("site", [None])[0]
-            offset = params.get("offset", [DEFAULT_OFFSET])[0]
-            limit = params.get("limit", [DEFAULT_LIMIT])[0]
+            offset = int(params.get("offset", [DEFAULT_OFFSET])[0])
+            limit = int(params.get("limit", [DEFAULT_LIMIT])[0])
+
             payload = get_trending_data(site, offset, limit)
             start_response("200 OK", [("Content-Type", "application/json")])
             yield payload


### PR DESCRIPTION
uwsgi is reporting an error about `timedelta` params not being integers:

```
[pid: 16194|app: 0|req: 1712/6478] 45.79.130.16 () {32 vars in 501 bytes} [Mon Sep 19 17:08:44 2016] GET /trending.json?site=theonion&offset=30&limit=10 => generated 61 bytes in 70 msecs (HTTP/1.1 400) 1 
headers in 54 bytes (3 switches on core 99)
2016-09-19 17:08:44,554 - ERROR - unsupported type for timedelta minutes component: str
Traceback (most recent call last):
  File "/var/venvs/pageview_digest/src/pageview-digest/pageview_digest/wsgi.py", line 93, in application
    payload = get_trending_data(site, offset, limit)
  File "/var/venvs/pageview_digest/src/pageview-digest/pageview_digest/wsgi.py", line 57, in get_trending_data
    offsetted = naive_now - timedelta(minutes=offset)
TypeError: unsupported type for timedelta minutes component: str
```

This ensures query parameters that should be `int` are casted as such.
